### PR TITLE
add prerequisites section for operator-sdk requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ spec:
 
 Run the following steps to run the operator locally. The operator will require `cluster-admin` permissions that can be applied using the resources provided in the deploy/ folder.
 
+Prerequisites:
+
+In order to run the operator locally, you will need to meet these [prerequisites](https://github.com/operator-framework/operator-sdk#prerequisites) and then follow these [instructions](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/install-operator-sdk.md#install-the-operator-sdk-cli) to install the operator-sdk.
+
 Pull in dependences
 ```
 $ export GO111MODULE=on


### PR DESCRIPTION
Added some links to the operator-sdk github to help install prerequisites.